### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ mpl-styles provide some decorators to decorate your matplotlib plots. Some style
 
 It is very easy to include your own style. Just define your rc params in a dictionary and include 
 them in a new decorator. Then make a 'Pull Request' to this repo. It would be nice to see a gallery 
-of beatiful styles here.
+of beautiful styles here.
 
-Otherwise, if you don't want to share your beatiful matplotlib configuration you can use your own 
+Otherwise, if you don't want to share your beautiful matplotlib configuration you can use your own 
 styles using my_style decorator which accepts a dictionary with your rc params.
 
 To use a style you just have to create your function with your plot and decorate the function with the 


### PR DESCRIPTION
@Pybonacci, I've corrected a typographical error in the documentation of the [mpl_styles](https://github.com/Pybonacci/mpl_styles) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
